### PR TITLE
Make white pop a bit more

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const black = '#000'
-const white = '#ccc'
+const white = '#bbb'
 const red = '#ff2e88'
 const green = '#50e3c2'
 const cyan = green


### PR DESCRIPTION
the difference between gray and white made it slightly too hard to tell the difference. Dropping the color to `#bbb` makes it easier to distinguish while still keeping the gray text easy enough to read from an accessibility standpoint (the minimum score for AAA accessibility rating is 7.0).

| Background Color | Foreground Color | Accessibility Score |
| --- | --- | --- |
| `#000` | `#ccc` | 13.08 |
| `#000` | `#bbb` | 10.94 |